### PR TITLE
Fix docs for updated note commands

### DIFF
--- a/ctx/cli.py
+++ b/ctx/cli.py
@@ -486,6 +486,9 @@ cli.add_command(switch, name='sw')
 cli.add_command(list, name='ls')
 cli.add_command(status, name='st')
 cli.add_command(add_note, name='n')
+cli.add_command(add_note, name='add-note')
+cli.add_command(show_notes, name='show-notes')
+cli.add_command(set_state, name='set-status')
 
 
 if __name__ == '__main__':

--- a/docs/agent-prompts/agentic-integration-guide.md
+++ b/docs/agent-prompts/agentic-integration-guide.md
@@ -30,7 +30,7 @@ Example:
 1. ctx switch {context_name}
 2. memory search "{relevant_pattern}"
 3. Execute task based on context + memory
-4. ctx add-note "RESULT: {outcome}"
+4. ctx note "RESULT: {outcome}"
 5. memory add observation to relevant entity
 ```
 
@@ -42,10 +42,10 @@ Pattern: State-driven branching with memory consultation
 if ctx_status == "🚫":
     memory search "unblock {blocker_type}"
     apply_solution_from_memory()
-    ctx set-status "💻"
+    ctx set-state "💻"
 elif ctx_status == "👀":
     check_review_feedback()
-    ctx add-note "FEEDBACK: {summary}"
+    ctx note "FEEDBACK: {summary}"
     update_memory_with_patterns()
 ```
 
@@ -55,13 +55,13 @@ elif ctx_status == "👀":
 Pattern: Capture failure -> Find pattern -> Apply fix -> Document
 
 on_error:
-    ctx add-note "ERROR: {error_details}"
+    ctx note "ERROR: {error_details}"
     solutions = memory search "{error_type} solution"
     if solutions:
         apply_solution(solutions[0])
-        ctx add-note "APPLIED: {solution_id}"
+        ctx note "APPLIED: {solution_id}"
     else:
-        ctx set-status "🚫"
+        ctx set-state "🚫"
         escalate_to_human()
 ```
 
@@ -72,7 +72,7 @@ on_error:
 ```
 Workflow:
 1. Analyze current context notes
-2. Extract patterns: ctx show-notes | analyze_patterns()
+2. Extract patterns: ctx notes | analyze_patterns()
 3. Memory query: Similar patterns in history
 4. Apply learned optimizations
 5. Create new memory observations
@@ -109,14 +109,14 @@ Query examples:
 Agent A (Developer):
 1. ctx create feature-xyz
 2. Implement feature
-3. ctx add-note "HANDOFF: Ready for review"
+3. ctx note "HANDOFF: Ready for review"
 4. memory relation: feature-xyz -> ready_for -> review
 
 Agent B (Reviewer):
 1. memory search "ready_for review"
 2. ctx switch feature-xyz
 3. Perform review
-4. ctx add-note "REVIEW: {feedback}"
+4. ctx note "REVIEW: {feedback}"
 ```
 
 ### 2. Continuous Learning
@@ -261,11 +261,11 @@ Regular maintenance:
 # Test context-memory sync
 ctx create test-integration
 memory create entity "test-integration" type="test"
-ctx add-note "TEST: Integration verified"
+ctx note "TEST: Integration verified"
 memory add observation "test-integration" "Integration verified"
 
 # Verify bidirectional lookup
-ctx show-notes | grep "TEST"
+ctx notes | grep "TEST"
 memory open "test-integration"
 ```
 

--- a/docs/agent-prompts/architecture-design-agent.md
+++ b/docs/agent-prompts/architecture-design-agent.md
@@ -15,22 +15,22 @@ primary_tools:
 ```
 New architecture design:
 1. ctx create ARCH-{project}-{component}
-2. ctx set-status 🏗️
+2. ctx set-state 🏗️
 3. Design metadata:
-   - ctx add-note "SCOPE: {system/component/integration}"
-   - ctx add-note "REQUIREMENTS: {functional} | {non-functional}"
-   - ctx add-note "CONSTRAINTS: {technical} | {business} | {regulatory}"
+   - ctx note "SCOPE: {system/component/integration}"
+   - ctx note "REQUIREMENTS: {functional} | {non-functional}"
+   - ctx note "CONSTRAINTS: {technical} | {business} | {regulatory}"
 ```
 
 ## Architecture Decision Records (ADR)
 
 ```
 ADR tracking:
-1. ctx add-note "ADR-{number}: {title}"
-2. ctx add-note "STATUS: {proposed/accepted/deprecated/superseded}"
-3. ctx add-note "CONTEXT: {problem_statement}"
-4. ctx add-note "DECISION: {chosen_solution}"
-5. ctx add-note "CONSEQUENCES: {positive} | {negative} | {risks}"
+1. ctx note "ADR-{number}: {title}"
+2. ctx note "STATUS: {proposed/accepted/deprecated/superseded}"
+3. ctx note "CONTEXT: {problem_statement}"
+4. ctx note "DECISION: {chosen_solution}"
+5. ctx note "CONSEQUENCES: {positive} | {negative} | {risks}"
 6. Memory relation: {component} -> implements -> {pattern}
 ```
 
@@ -39,19 +39,19 @@ ADR tracking:
 ```
 Pattern selection:
 1. Memory search: "{problem_type} pattern"
-2. ctx add-note "PATTERN: {pattern_name} | USE_CASE: {applicability}"
-3. ctx add-note "IMPLEMENTATION: {language/framework} specific notes"
-4. ctx add-note "TRADE-OFFS: {benefits} vs {drawbacks}"
+2. ctx note "PATTERN: {pattern_name} | USE_CASE: {applicability}"
+3. ctx note "IMPLEMENTATION: {language/framework} specific notes"
+4. ctx note "TRADE-OFFS: {benefits} vs {drawbacks}"
 ```
 
 ## System Component Design
 
 ```
 Component specification:
-- ctx add-note "COMPONENT: {name} | TYPE: {service/library/module}"
-- ctx add-note "INTERFACE: {API_spec} | PROTOCOL: {REST/gRPC/GraphQL}"
-- ctx add-note "DEPENDENCIES: {internal}: [{list}] | {external}: [{list}]"
-- ctx add-note "DATA: {storage_type} | SCHEMA: {version}"
+- ctx note "COMPONENT: {name} | TYPE: {service/library/module}"
+- ctx note "INTERFACE: {API_spec} | PROTOCOL: {REST/gRPC/GraphQL}"
+- ctx note "DEPENDENCIES: {internal}: [{list}] | {external}: [{list}]"
+- ctx note "DATA: {storage_type} | SCHEMA: {version}"
 ```
 
 ## Architecture States
@@ -68,49 +68,49 @@ Risk states:
 
 ```
 Integration planning:
-1. ctx add-note "INTEGRATION: {system_A} <-> {system_B}"
-2. ctx add-note "PROTOCOL: {sync/async} | FORMAT: {JSON/XML/protobuf}"
-3. ctx add-note "SLA: {latency}ms p99 | {throughput} rps"
-4. ctx add-note "FAILURE: {retry_strategy} | CIRCUIT_BREAKER: {config}"
+1. ctx note "INTEGRATION: {system_A} <-> {system_B}"
+2. ctx note "PROTOCOL: {sync/async} | FORMAT: {JSON/XML/protobuf}"
+3. ctx note "SLA: {latency}ms p99 | {throughput} rps"
+4. ctx note "FAILURE: {retry_strategy} | CIRCUIT_BREAKER: {config}"
 ```
 
 ## Performance Architecture
 
 ```
 Performance considerations:
-- ctx add-note "LOAD: {expected_rps} | PEAK: {max_rps}"
-- ctx add-note "LATENCY: {target}ms p50/p95/p99"
-- ctx add-note "SCALING: {horizontal/vertical} | TRIGGER: {metric}@{threshold}"
-- ctx add-note "CACHE: {layer} - {strategy} - TTL: {duration}"
+- ctx note "LOAD: {expected_rps} | PEAK: {max_rps}"
+- ctx note "LATENCY: {target}ms p50/p95/p99"
+- ctx note "SCALING: {horizontal/vertical} | TRIGGER: {metric}@{threshold}"
+- ctx note "CACHE: {layer} - {strategy} - TTL: {duration}"
 ```
 
 ## Security Architecture
 
 ```
 Security design:
-1. ctx add-note "AUTHZ: {RBAC/ABAC/custom} | PROVIDER: {implementation}"
-2. ctx add-note "ENCRYPTION: {at_rest}: {method} | {in_transit}: {TLS_version}"
-3. ctx add-note "SECRETS: {management_system} | ROTATION: {frequency}"
-4. ctx add-note "AUDIT: {events_logged} | RETENTION: {duration}"
+1. ctx note "AUTHZ: {RBAC/ABAC/custom} | PROVIDER: {implementation}"
+2. ctx note "ENCRYPTION: {at_rest}: {method} | {in_transit}: {TLS_version}"
+3. ctx note "SECRETS: {management_system} | ROTATION: {frequency}"
+4. ctx note "AUDIT: {events_logged} | RETENTION: {duration}"
 ```
 
 ## Data Architecture
 
 ```
 Data design decisions:
-- ctx add-note "STORAGE: {type} - {technology} | VOLUME: {size_estimate}"
-- ctx add-note "CONSISTENCY: {strong/eventual} | CAP: {choice}"
-- ctx add-note "PARTITION: {strategy} | SHARD_KEY: {field}"
-- ctx add-note "BACKUP: {frequency} | RPO: {time} | RTO: {time}"
+- ctx note "STORAGE: {type} - {technology} | VOLUME: {size_estimate}"
+- ctx note "CONSISTENCY: {strong/eventual} | CAP: {choice}"
+- ctx note "PARTITION: {strategy} | SHARD_KEY: {field}"
+- ctx note "BACKUP: {frequency} | RPO: {time} | RTO: {time}"
 ```
 
 ## Technology Stack Selection
 
 ```
 Stack decisions:
-1. ctx add-note "LANG: {language} v{version} | FRAMEWORK: {name} v{version}"
-2. ctx add-note "INFRA: {cloud/on-prem} | ORCHESTRATION: {k8s/ecs/custom}"
-3. ctx add-note "MONITORING: {metrics}: {tool} | {logs}: {tool} | {traces}: {tool}"
+1. ctx note "LANG: {language} v{version} | FRAMEWORK: {name} v{version}"
+2. ctx note "INFRA: {cloud/on-prem} | ORCHESTRATION: {k8s/ecs/custom}"
+3. ctx note "MONITORING: {metrics}: {tool} | {logs}: {tool} | {traces}: {tool}"
 4. Memory: Link technology choices to past success patterns
 ```
 
@@ -118,10 +118,10 @@ Stack decisions:
 
 ```
 Cost modeling:
-- ctx add-note "COMPUTE: ${estimate}/month | BASIS: {instance_types}"
-- ctx add-note "STORAGE: ${estimate}/month | GROWTH: {rate}"
-- ctx add-note "TRANSFER: ${estimate}/month | EGRESS: {GB_estimate}"
-- ctx add-note "OPTIMIZATION: {reserved/spot/savings_plan}"
+- ctx note "COMPUTE: ${estimate}/month | BASIS: {instance_types}"
+- ctx note "STORAGE: ${estimate}/month | GROWTH: {rate}"
+- ctx note "TRANSFER: ${estimate}/month | EGRESS: {GB_estimate}"
+- ctx note "OPTIMIZATION: {reserved/spot/savings_plan}"
 ```
 
 ## Migration Architecture
@@ -129,21 +129,21 @@ Cost modeling:
 ```
 Migration planning:
 1. ctx create MIGRATE-{from}-to-{to}
-2. ctx add-note "STRATEGY: {big_bang/parallel/gradual}"
-3. ctx add-note "PHASE_{n}: {description} | DURATION: {estimate}"
-4. ctx add-note "ROLLBACK: {point} | PROCEDURE: {steps}"
-5. ctx add-note "VALIDATION: {method} | SUCCESS_CRITERIA: {metrics}"
+2. ctx note "STRATEGY: {big_bang/parallel/gradual}"
+3. ctx note "PHASE_{n}: {description} | DURATION: {estimate}"
+4. ctx note "ROLLBACK: {point} | PROCEDURE: {steps}"
+5. ctx note "VALIDATION: {method} | SUCCESS_CRITERIA: {metrics}"
 ```
 
 ## Architecture Review Checklist
 
 ```
 Review preparation:
-1. ctx add-note "REVIEW: Scalability - {findings}"
-2. ctx add-note "REVIEW: Security - {findings}"
-3. ctx add-note "REVIEW: Reliability - {findings}"
-4. ctx add-note "REVIEW: Maintainability - {findings}"
-5. ctx add-note "REVIEW: Cost - {findings}"
+1. ctx note "REVIEW: Scalability - {findings}"
+2. ctx note "REVIEW: Security - {findings}"
+3. ctx note "REVIEW: Reliability - {findings}"
+4. ctx note "REVIEW: Maintainability - {findings}"
+5. ctx note "REVIEW: Cost - {findings}"
 6. Generate diagram: Architecture overview with components and flows
 ```
 

--- a/docs/agent-prompts/backend-dev-agent.md
+++ b/docs/agent-prompts/backend-dev-agent.md
@@ -15,11 +15,11 @@ primary_tools:
 ```
 Initialize development context for service implementation:
 1. Create context: ctx create {JIRA_ID}-{service_name}
-2. Set status: ctx set-status 💻
+2. Set status: ctx set-state 💻
 3. Add technical metadata:
-   - ctx add-note "SERVICE: {service_name} | ENDPOINT: {endpoint_path}"
-   - ctx add-note "BRANCH: feature/{JIRA_ID} | TARGET: {target_env}"
-   - ctx add-note "DEPENDENCIES: {list_dependencies}"
+   - ctx note "SERVICE: {service_name} | ENDPOINT: {endpoint_path}"
+   - ctx note "BRANCH: feature/{JIRA_ID} | TARGET: {target_env}"
+   - ctx note "DEPENDENCIES: {list_dependencies}"
 4. Create memory entities:
    - Entity: {service_name} (type: service)
    - Relations: implements -> {endpoint_path}, uses -> {dependencies}
@@ -31,24 +31,24 @@ Initialize development context for service implementation:
 ```
 When implementing new service endpoint:
 - Switch context: ctx switch {JIRA_ID}-{service_name}
-- Update status: ctx set-status 🔨
-- Track progress: ctx add-note "IMPL: {component} - {status}"
+- Update status: ctx set-state 🔨
+- Track progress: ctx note "IMPL: {component} - {status}"
 - Memory update: Add observation to service entity with implementation decisions
 ```
 
 ### 2. Test Development
 ```
 For unit test creation:
-- ctx add-note "TEST: {test_file} - {coverage}% - {test_count} tests"
-- ctx add-note "MOCK: {external_service} - {mock_strategy}"
+- ctx note "TEST: {test_file} - {coverage}% - {test_count} tests"
+- ctx note "MOCK: {external_service} - {mock_strategy}"
 - Memory relation: {test_class} -> tests -> {service_method}
 ```
 
 ### 3. Integration Point Documentation
 ```
 When integrating with external services:
-- ctx add-note "INTEGRATION: {service} - {endpoint} - {auth_method}"
-- ctx add-note "CONFIG: {env_var} = {value_pattern}"
+- ctx note "INTEGRATION: {service} - {endpoint} - {auth_method}"
+- ctx note "CONFIG: {env_var} = {value_pattern}"
 - Memory entity: {external_service} (type: integration)
 - Memory relation: {service_name} -> depends_on -> {external_service}
 ```
@@ -67,9 +67,9 @@ Blocked States:
 
 ```
 Before submitting PR:
-1. ctx set-status 👀
-2. ctx add-note "PR: #{pr_number} - {pr_url}"
-3. ctx add-note "CHANGES: {files_changed} files, +{additions}/-{deletions}"
+1. ctx set-state 👀
+2. ctx note "PR: #{pr_number} - {pr_url}"
+3. ctx note "CHANGES: {files_changed} files, +{additions}/-{deletions}"
 4. Generate handoff:
    - Create contexts/{JIRA_ID}-handoff.md
    - Include: API contracts, test coverage, deployment notes
@@ -81,7 +81,7 @@ Before submitting PR:
 Sequential thinking with memory:
 1. Search existing patterns: memory search "similar service implementation"
 2. Load context: ctx switch {context_name}
-3. Retrieve decisions: ctx show-notes | grep "DECISION:"
+3. Retrieve decisions: ctx notes | grep "DECISION:"
 4. Update memory: Create observation linking current implementation to pattern
 ```
 
@@ -89,8 +89,8 @@ Sequential thinking with memory:
 
 ```
 When encountering errors:
-- ctx add-note "ERROR: {error_type} - {file}:{line} - {description}"
-- ctx add-note "FIX: {solution_description} - {commit_hash}"
+- ctx note "ERROR: {error_type} - {file}:{line} - {description}"
+- ctx note "FIX: {solution_description} - {commit_hash}"
 - Memory observation: Add error pattern and solution to service entity
 ```
 
@@ -98,7 +98,7 @@ When encountering errors:
 
 ```
 On completion:
-1. ctx set-status ✅
+1. ctx set-state ✅
 2. Export context: ctx export {context_name} > archives/{JIRA_ID}.json
 3. Memory relation: {service_name} -> completed_in -> {sprint_id}
 4. ctx close {context_name}

--- a/docs/agent-prompts/devops-sre-agent.md
+++ b/docs/agent-prompts/devops-sre-agent.md
@@ -15,11 +15,11 @@ primary_tools:
 ```
 Incident initialization:
 1. ctx create INC-{number}-{service}
-2. ctx set-status 🔥
+2. ctx set-state 🔥
 3. Incident metadata:
-   - ctx add-note "SEVERITY: {P1/P2/P3} | SERVICE: {affected_service}"
-   - ctx add-note "IMPACT: {user_impact} | START: {timestamp}"
-   - ctx add-note "SYMPTOMS: {observed_behavior}"
+   - ctx note "SEVERITY: {P1/P2/P3} | SERVICE: {affected_service}"
+   - ctx note "IMPACT: {user_impact} | START: {timestamp}"
+   - ctx note "SYMPTOMS: {observed_behavior}"
 ```
 
 ## Deployment Context
@@ -27,11 +27,11 @@ Incident initialization:
 ```
 Deployment tracking:
 1. ctx create DEPLOY-{date}-{service}-{version}
-2. ctx set-status 🚀
+2. ctx set-state 🚀
 3. Deployment info:
-   - ctx add-note "VERSION: {from_version} -> {to_version}"
-   - ctx add-note "STRATEGY: {blue_green/canary/rolling}"
-   - ctx add-note "ROLLBACK: {rollback_version} | TIME: {rollback_window}"
+   - ctx note "VERSION: {from_version} -> {to_version}"
+   - ctx note "STRATEGY: {blue_green/canary/rolling}"
+   - ctx note "ROLLBACK: {rollback_version} | TIME: {rollback_window}"
 ```
 
 ## Incident Management Prompts
@@ -39,8 +39,8 @@ Deployment tracking:
 ### 1. Initial Response
 ```
 On incident detection:
-- ctx add-note "DETECTED: {monitoring_alert} at {timestamp}"
-- ctx add-note "METRICS: {metric_name} = {value} (threshold: {threshold})"
+- ctx note "DETECTED: {monitoring_alert} at {timestamp}"
+- ctx note "METRICS: {metric_name} = {value} (threshold: {threshold})"
 - Memory search: "similar incident {service} {symptom}"
 - Apply runbook if pattern matches
 ```
@@ -48,18 +48,18 @@ On incident detection:
 ### 2. Investigation
 ```
 During investigation:
-- ctx add-note "CHECK: {component} - {status}"
-- ctx add-note "LOG: {error_pattern} found in {log_source}"
-- ctx add-note "CORRELATION: {related_event} at {timestamp}"
+- ctx note "CHECK: {component} - {status}"
+- ctx note "LOG: {error_pattern} found in {log_source}"
+- ctx note "CORRELATION: {related_event} at {timestamp}"
 - Memory: Update incident patterns with new findings
 ```
 
 ### 3. Mitigation
 ```
 Mitigation actions:
-- ctx add-note "ACTION: {mitigation_step} - {result}"
-- ctx add-note "WORKAROUND: {temporary_fix} applied at {time}"
-- If escalated: ctx set-status 🚨
+- ctx note "ACTION: {mitigation_step} - {result}"
+- ctx note "WORKAROUND: {temporary_fix} applied at {time}"
+- If escalated: ctx set-state 🚨
 - Memory relation: {incident} -> mitigated_by -> {action}
 ```
 
@@ -78,9 +78,9 @@ Failure states:
 ```
 Infrastructure changes:
 1. ctx create INFRA-{change_id}-{component}
-2. ctx add-note "CHANGE: {description} | RISK: {risk_level}"
-3. ctx add-note "TERRAFORM: {plan_output_summary}"
-4. ctx add-note "APPROVAL: {approver} at {timestamp}"
+2. ctx note "CHANGE: {description} | RISK: {risk_level}"
+3. ctx note "TERRAFORM: {plan_output_summary}"
+4. ctx note "APPROVAL: {approver} at {timestamp}"
 ```
 
 ## Performance Optimization Context
@@ -88,19 +88,19 @@ Infrastructure changes:
 ```
 Performance investigation:
 - ctx create PERF-{service}-{issue_type}
-- ctx add-note "BASELINE: {metric} = {value} @ {percentile}"
-- ctx add-note "DEGRADATION: {percent}% increase in {metric}"
-- ctx add-note "HYPOTHESIS: {root_cause_theory}"
-- ctx add-note "TEST: {optimization} resulted in {improvement}%"
+- ctx note "BASELINE: {metric} = {value} @ {percentile}"
+- ctx note "DEGRADATION: {percent}% increase in {metric}"
+- ctx note "HYPOTHESIS: {root_cause_theory}"
+- ctx note "TEST: {optimization} resulted in {improvement}%"
 ```
 
 ## Capacity Planning
 
 ```
 Capacity tracking:
-- ctx add-note "CAPACITY: {resource} at {utilization}% (limit: {threshold}%)"
-- ctx add-note "PROJECTION: {resource} exhaustion in {days} days"
-- ctx add-note "RECOMMENDATION: Scale {component} by {factor}x"
+- ctx note "CAPACITY: {resource} at {utilization}% (limit: {threshold}%)"
+- ctx note "PROJECTION: {resource} exhaustion in {days} days"
+- ctx note "RECOMMENDATION: Scale {component} by {factor}x"
 - Memory: Historical growth patterns for trending
 ```
 
@@ -108,10 +108,10 @@ Capacity tracking:
 
 ```
 PIR generation:
-1. ctx set-status 📊
-2. Export timeline: ctx show-notes | grep -E "(DETECTED|ACTION|RESOLVED)"
-3. ctx add-note "RCA: {root_cause_description}"
-4. ctx add-note "PREVENTION: {preventive_measures}"
+1. ctx set-state 📊
+2. Export timeline: ctx notes | grep -E "(DETECTED|ACTION|RESOLVED)"
+3. ctx note "RCA: {root_cause_description}"
+4. ctx note "PREVENTION: {preventive_measures}"
 5. Memory: Create runbook entity from incident learnings
 ```
 
@@ -119,8 +119,8 @@ PIR generation:
 
 ```
 Config management:
-- ctx add-note "DRIFT: {config_item} - expected: {value1}, actual: {value2}"
-- ctx add-note "SOURCE: {git_commit} vs {deployed_version}"
+- ctx note "DRIFT: {config_item} - expected: {value1}, actual: {value2}"
+- ctx note "SOURCE: {git_commit} vs {deployed_version}"
 - Memory relation: {service} -> has_config -> {config_version}
 ```
 
@@ -129,18 +129,18 @@ Config management:
 ```
 Security context:
 1. ctx create SEC-{incident_id}-{type}
-2. ctx set-status 🛡️
-3. ctx add-note "VECTOR: {attack_vector} | SOURCE: {source_ip}"
-4. ctx add-note "AFFECTED: {resources} | DATA: {data_exposure_risk}"
-5. ctx add-note "CONTAINMENT: {action} completed at {time}"
+2. ctx set-state 🛡️
+3. ctx note "VECTOR: {attack_vector} | SOURCE: {source_ip}"
+4. ctx note "AFFECTED: {resources} | DATA: {data_exposure_risk}"
+5. ctx note "CONTAINMENT: {action} completed at {time}"
 ```
 
 ## Monitoring Alert Patterns
 
 ```
 Alert correlation:
-- ctx add-note "ALERT: {alert_name} - {count} occurrences in {timeframe}"
-- ctx add-note "CORRELATION: {alert1} -> {alert2} (lag: {seconds}s)"
+- ctx note "ALERT: {alert_name} - {count} occurrences in {timeframe}"
+- ctx note "CORRELATION: {alert1} -> {alert2} (lag: {seconds}s)"
 - Memory: Build alert correlation graph
-- ctx add-note "PATTERN: {pattern_name} detected, applying runbook {id}"
+- ctx note "PATTERN: {pattern_name} detected, applying runbook {id}"
 ```

--- a/docs/agent-prompts/personal-productivity-agent.md
+++ b/docs/agent-prompts/personal-productivity-agent.md
@@ -15,11 +15,11 @@ primary_tools:
 ```
 Morning initialization:
 1. ctx create daily-{YYYY-MM-DD}
-2. ctx set-status ☀️
+2. ctx set-state ☀️
 3. Daily setup:
-   - ctx add-note "FOCUS: {main_priority_today}"
-   - ctx add-note "MEETINGS: {count} scheduled | BLOCKS: {deep_work_blocks}"
-   - ctx add-note "ENERGY: {high/medium/low} | MOOD: {emoji}"
+   - ctx note "FOCUS: {main_priority_today}"
+   - ctx note "MEETINGS: {count} scheduled | BLOCKS: {deep_work_blocks}"
+   - ctx note "ENERGY: {high/medium/low} | MOOD: {emoji}"
 ```
 
 ## Task Management Prompts
@@ -27,16 +27,16 @@ Morning initialization:
 ### 1. Task Capture
 ```
 Quick task entry:
-- ctx add-note "TODO: {task_description} | DUE: {date} | EST: {time_estimate}"
-- ctx add-note "CONTEXT: @{location} #{project} !{priority}"
+- ctx note "TODO: {task_description} | DUE: {date} | EST: {time_estimate}"
+- ctx note "CONTEXT: @{location} #{project} !{priority}"
 - Memory: Link task to project entity
 ```
 
 ### 2. Time Blocking
 ```
 Time block management:
-- ctx add-note "BLOCK: {start_time}-{end_time} | {task_type} | {description}"
-- ctx add-note "COMPLETED: {actual_time} | QUALITY: {1-5} | INTERRUPTIONS: {count}"
+- ctx note "BLOCK: {start_time}-{end_time} | {task_type} | {description}"
+- ctx note "COMPLETED: {actual_time} | QUALITY: {1-5} | INTERRUPTIONS: {count}"
 - Memory: Track productivity patterns by time of day
 ```
 
@@ -44,9 +44,9 @@ Time block management:
 ```
 Project context:
 - ctx create project-{name}
-- ctx add-note "GOAL: {outcome} | DEADLINE: {date}"
-- ctx add-note "MILESTONE: {name} - {status} - {completion}%"
-- ctx add-note "BLOCKER: {description} | NEED: {required_action}"
+- ctx note "GOAL: {outcome} | DEADLINE: {date}"
+- ctx note "MILESTONE: {name} - {status} - {completion}%"
+- ctx note "BLOCKER: {description} | NEED: {required_action}"
 ```
 
 ## Learning Context
@@ -54,11 +54,11 @@ Project context:
 ```
 Learning session tracking:
 1. ctx create learn-{topic}
-2. ctx set-status 📚
+2. ctx set-state 📚
 3. Knowledge capture:
-   - ctx add-note "SOURCE: {book/article/video} - {url/reference}"
-   - ctx add-note "INSIGHT: {key_learning}"
-   - ctx add-note "ACTION: {how_to_apply}"
+   - ctx note "SOURCE: {book/article/video} - {url/reference}"
+   - ctx note "INSIGHT: {key_learning}"
+   - ctx note "ACTION: {how_to_apply}"
    - Memory: Create knowledge entity with connections
 ```
 
@@ -79,10 +79,10 @@ Weekly review process:
 1. ctx create weekly-review-{week_number}
 2. Accomplishments:
    - ctx list | grep "✅" > completed_tasks.tmp
-   - ctx add-note "WINS: {top_3_accomplishments}"
-   - ctx add-note "METRICS: {tasks_completed}/{tasks_planned}"
+   - ctx note "WINS: {top_3_accomplishments}"
+   - ctx note "METRICS: {tasks_completed}/{tasks_planned}"
 3. Planning:
-   - ctx add-note "NEXT_WEEK: {top_3_priorities}"
+   - ctx note "NEXT_WEEK: {top_3_priorities}"
    - Memory: Analyze productivity patterns
 ```
 
@@ -90,9 +90,9 @@ Weekly review process:
 
 ```
 Wellness context:
-- ctx add-note "SLEEP: {hours}h | QUALITY: {1-5}"
-- ctx add-note "EXERCISE: {type} - {duration} - {intensity}"
-- ctx add-note "MOOD: {emoji} | ENERGY: {1-10} | STRESS: {1-10}"
+- ctx note "SLEEP: {hours}h | QUALITY: {1-5}"
+- ctx note "EXERCISE: {type} - {duration} - {intensity}"
+- ctx note "MOOD: {emoji} | ENERGY: {1-10} | STRESS: {1-10}"
 - Memory: Correlate wellness metrics with productivity
 ```
 
@@ -101,10 +101,10 @@ Wellness context:
 ```
 Decision context:
 1. ctx create decision-{topic}
-2. ctx add-note "QUESTION: {decision_to_make}"
-3. ctx add-note "OPTION: {option_name} | PROS: {list} | CONS: {list}"
-4. ctx add-note "CRITERIA: {factor} - WEIGHT: {importance}"
-5. ctx add-note "DECISION: {chosen_option} | RATIONALE: {reasoning}"
+2. ctx note "QUESTION: {decision_to_make}"
+3. ctx note "OPTION: {option_name} | PROS: {list} | CONS: {list}"
+4. ctx note "CRITERIA: {factor} - WEIGHT: {importance}"
+5. ctx note "DECISION: {chosen_option} | RATIONALE: {reasoning}"
 6. Memory: Track decision patterns and outcomes
 ```
 
@@ -113,9 +113,9 @@ Decision context:
 ```
 Reading tracking:
 - ctx create reading-{year}
-- ctx add-note "BOOK: {title} by {author} | STATUS: {reading/completed}"
-- ctx add-note "RATING: {1-5} | TAGS: {categories}"
-- ctx add-note "TAKEAWAY: {main_lesson} | APPLICATION: {how_to_use}"
+- ctx note "BOOK: {title} by {author} | STATUS: {reading/completed}"
+- ctx note "RATING: {1-5} | TAGS: {categories}"
+- ctx note "TAKEAWAY: {main_lesson} | APPLICATION: {how_to_use}"
 ```
 
 ## Habit Tracking
@@ -124,8 +124,8 @@ Reading tracking:
 Habit context:
 1. ctx create habit-{habit_name}
 2. Daily check-in:
-   - ctx add-note "CHECK: {date} - {completed: Y/N} | STREAK: {days}"
-   - ctx add-note "OBSTACLE: {what_prevented} | SOLUTION: {adjustment}"
+   - ctx note "CHECK: {date} - {completed: Y/N} | STREAK: {days}"
+   - ctx note "OBSTACLE: {what_prevented} | SOLUTION: {adjustment}"
 3. Memory: Track habit formation patterns
 ```
 
@@ -135,10 +135,10 @@ Habit context:
 Monthly retrospective:
 1. ctx create retro-{YYYY-MM}
 2. Reflection prompts:
-   - ctx add-note "GRATEFUL: {three_things}"
-   - ctx add-note "LEARNED: {key_lessons}"
-   - ctx add-note "IMPROVED: {areas_of_growth}"
-   - ctx add-note "CHALLENGE: {biggest_obstacle} | OVERCAME: {how}"
+   - ctx note "GRATEFUL: {three_things}"
+   - ctx note "LEARNED: {key_lessons}"
+   - ctx note "IMPROVED: {areas_of_growth}"
+   - ctx note "CHALLENGE: {biggest_obstacle} | OVERCAME: {how}"
 3. Memory: Build personal growth timeline
 ```
 

--- a/docs/agent-prompts/qa-test-agent.md
+++ b/docs/agent-prompts/qa-test-agent.md
@@ -15,11 +15,11 @@ primary_tools:
 ```
 Initialize test context:
 1. ctx create {JIRA_ID}-qa-{test_type}
-2. ctx set-status 🧪
+2. ctx set-state 🧪
 3. Test metadata:
-   - ctx add-note "TEST_SUITE: {suite_name} | ENV: {test_env}"
-   - ctx add-note "BUILD: {build_number} | VERSION: {app_version}"
-   - ctx add-note "SCOPE: {test_scope} | PRIORITY: {P1/P2/P3}"
+   - ctx note "TEST_SUITE: {suite_name} | ENV: {test_env}"
+   - ctx note "BUILD: {build_number} | VERSION: {app_version}"
+   - ctx note "SCOPE: {test_scope} | PRIORITY: {P1/P2/P3}"
 ```
 
 ## Test Execution Prompts
@@ -27,17 +27,17 @@ Initialize test context:
 ### 1. Test Case Execution
 ```
 For each test case:
-- ctx add-note "TC_{id}: {test_name} - {PASS/FAIL/BLOCKED}"
-- ctx add-note "DURATION: {time}ms | DATA: {test_data_set}"
-- If failed: ctx add-note "FAILURE: {reason} | SCREENSHOT: {path}"
+- ctx note "TC_{id}: {test_name} - {PASS/FAIL/BLOCKED}"
+- ctx note "DURATION: {time}ms | DATA: {test_data_set}"
+- If failed: ctx note "FAILURE: {reason} | SCREENSHOT: {path}"
 - Memory: Create defect pattern entity if new failure type
 ```
 
 ### 2. Regression Testing
 ```
 During regression:
-- ctx add-note "REGRESSION: {suite} - {passed}/{total} passed"
-- ctx add-note "FLAKY: {test_id} - {failure_rate}% over {runs} runs"
+- ctx note "REGRESSION: {suite} - {passed}/{total} passed"
+- ctx note "FLAKY: {test_id} - {failure_rate}% over {runs} runs"
 - Memory search: "flaky test {test_name}" to check history
 - Memory relation: {test_case} -> exhibits -> {flaky_pattern}
 ```
@@ -45,19 +45,19 @@ During regression:
 ### 3. Integration Testing
 ```
 API/Integration tests:
-- ctx add-note "API_TEST: {endpoint} - {method} - {status_code}"
-- ctx add-note "RESPONSE_TIME: {avg}ms (min: {min}, max: {max})"
-- ctx add-note "CONTRACT: {validation_status} - {schema_version}"
+- ctx note "API_TEST: {endpoint} - {method} - {status_code}"
+- ctx note "RESPONSE_TIME: {avg}ms (min: {min}, max: {max})"
+- ctx note "CONTRACT: {validation_status} - {schema_version}"
 ```
 
 ## Defect Tracking
 
 ```
 When logging defects:
-1. ctx set-status 🐛
-2. ctx add-note "DEFECT: {id} - {severity} - {component}"
-3. ctx add-note "REPRO: {steps_to_reproduce}"
-4. ctx add-note "EXPECTED: {expected} | ACTUAL: {actual}"
+1. ctx set-state 🐛
+2. ctx note "DEFECT: {id} - {severity} - {component}"
+3. ctx note "REPRO: {steps_to_reproduce}"
+4. ctx note "EXPECTED: {expected} | ACTUAL: {actual}"
 5. Memory entity: {defect_pattern} (type: defect)
 6. Memory relation: {test_case} -> discovered -> {defect_pattern}
 ```
@@ -76,9 +76,9 @@ Issue States:
 
 ```
 Generate test report:
-1. ctx show-notes | grep "TC_" > test_results.tmp
+1. ctx notes | grep "TC_" > test_results.tmp
 2. Calculate: pass_rate, defect_count, blocked_tests
-3. ctx add-note "SUMMARY: {pass_rate}% pass | {defects} defects | {blocked} blocked"
+3. ctx note "SUMMARY: {pass_rate}% pass | {defects} defects | {blocked} blocked"
 4. Create: contexts/{JIRA_ID}-test-report.md
 ```
 
@@ -88,7 +88,7 @@ Generate test report:
 Intelligent test selection:
 1. Memory search: "defects in {component}"
 2. Identify high-risk areas from memory
-3. ctx add-note "RISK_BASED: Testing {component} due to {defect_history}"
+3. ctx note "RISK_BASED: Testing {component} due to {defect_history}"
 4. Prioritize test cases based on defect patterns
 ```
 
@@ -97,9 +97,9 @@ Intelligent test selection:
 ```
 Performance test tracking:
 - ctx create {JIRA_ID}-perf-{scenario}
-- ctx add-note "BASELINE: {metric} = {value} {unit}"
-- ctx add-note "LOAD: {users} users, {duration} duration"
-- ctx add-note "RESULT: {metric} = {value} ({percent_change}% from baseline)"
+- ctx note "BASELINE: {metric} = {value} {unit}"
+- ctx note "LOAD: {users} users, {duration} duration"
+- ctx note "RESULT: {metric} = {value} ({percent_change}% from baseline)"
 - Memory observation: Performance regression patterns
 ```
 
@@ -107,9 +107,9 @@ Performance test tracking:
 
 ```
 For automation candidates:
-1. ctx add-note "AUTOMATE: {test_id} - {priority} - {complexity}"
-2. ctx add-note "SELECTORS: {ui_elements_identified}"
-3. ctx add-note "DATA_DRIVEN: {parameterization_needed}"
+1. ctx note "AUTOMATE: {test_id} - {priority} - {complexity}"
+2. ctx note "SELECTORS: {ui_elements_identified}"
+3. ctx note "DATA_DRIVEN: {parameterization_needed}"
 4. Export: Test steps and validation points for automation team
 ```
 
@@ -117,7 +117,7 @@ For automation candidates:
 
 ```
 Environment-related tracking:
-- ctx add-note "ENV_ISSUE: {component} - {issue_type}"
-- ctx add-note "WORKAROUND: {temporary_solution}"
+- ctx note "ENV_ISSUE: {component} - {issue_type}"
+- ctx note "WORKAROUND: {temporary_solution}"
 - Memory: Track environment-specific issues for pattern recognition
 ```

--- a/examples/agent-backend-dev.sh
+++ b/examples/agent-backend-dev.sh
@@ -5,36 +5,36 @@ echo "=== Backend Developer Agent Workflow ==="
 
 # Initialize context for new service
 ctx create PAYMENT-5320-refund-service
-ctx set-status 💻
-ctx add-note "SERVICE: RefundService | ENDPOINT: /api/v1/refunds"
-ctx add-note "BRANCH: feature/PAYMENT-5320 | TARGET: dev-env"
-ctx add-note "DEPENDENCIES: PaymentGateway, UserService, NotificationService"
+ctx set-state 💻
+ctx note "SERVICE: RefundService | ENDPOINT: /api/v1/refunds"
+ctx note "BRANCH: feature/PAYMENT-5320 | TARGET: dev-env"
+ctx note "DEPENDENCIES: PaymentGateway, UserService, NotificationService"
 
 # Simulate development progress
 echo -e "\n📝 Development Progress:"
-ctx add-note "IMPL: Database schema - COMPLETE"
-ctx add-note "IMPL: Service layer - IN_PROGRESS"
-ctx add-note "DECISION: Using event-driven architecture for async processing"
+ctx note "IMPL: Database schema - COMPLETE"
+ctx note "IMPL: Service layer - IN_PROGRESS"
+ctx note "DECISION: Using event-driven architecture for async processing"
 
 # Error encountered
-ctx add-note "ERROR: Connection timeout to PaymentGateway - ConnectionPool exhausted"
-ctx add-note "FIX: Increased pool size from 10 to 50 - commit: abc123"
+ctx note "ERROR: Connection timeout to PaymentGateway - ConnectionPool exhausted"
+ctx note "FIX: Increased pool size from 10 to 50 - commit: abc123"
 
 # Test development
 echo -e "\n🧪 Test Development:"
-ctx add-note "TEST: refund.service.test.js - 95% coverage - 18 tests"
-ctx add-note "MOCK: PaymentGateway - Using WireMock for integration tests"
+ctx note "TEST: refund.service.test.js - 95% coverage - 18 tests"
+ctx note "MOCK: PaymentGateway - Using WireMock for integration tests"
 
 # Integration documentation
-ctx add-note "INTEGRATION: PaymentGateway - REST - OAuth2"
-ctx add-note "CONFIG: PAYMENT_GATEWAY_URL = https://api.payment.com/v2"
-ctx add-note "CONFIG: PAYMENT_GATEWAY_TIMEOUT = 30s"
+ctx note "INTEGRATION: PaymentGateway - REST - OAuth2"
+ctx note "CONFIG: PAYMENT_GATEWAY_URL = https://api.payment.com/v2"
+ctx note "CONFIG: PAYMENT_GATEWAY_TIMEOUT = 30s"
 
 # Ready for review
 echo -e "\n👀 Code Review:"
-ctx set-status 👀
-ctx add-note "PR: #1091 - https://github.com/org/repo/pull/1091"
-ctx add-note "CHANGES: 12 files, +847/-123"
+ctx set-state 👀
+ctx note "PR: #1091 - https://github.com/org/repo/pull/1091"
+ctx note "CHANGES: 12 files, +847/-123"
 
 # Show current status
 echo -e "\n📊 Current Context Status:"

--- a/examples/agent-incident-response.sh
+++ b/examples/agent-incident-response.sh
@@ -5,43 +5,43 @@ echo "=== Incident Response Agent Workflow ==="
 
 # Incident detected
 ctx create INC-2025-0147-payment-api
-ctx set-status 🔥
-ctx add-note "SEVERITY: P1 | SERVICE: payment-api"
-ctx add-note "IMPACT: 500 errors on /api/v1/process - 15% of requests failing"
-ctx add-note "SYMPTOMS: Spike in 5xx errors, latency increased 10x"
+ctx set-state 🔥
+ctx note "SEVERITY: P1 | SERVICE: payment-api"
+ctx note "IMPACT: 500 errors on /api/v1/process - 15% of requests failing"
+ctx note "SYMPTOMS: Spike in 5xx errors, latency increased 10x"
 
 # Initial response
 echo -e "\n🔍 Investigation:"
-ctx add-note "DETECTED: CloudWatch alarm 'payment-api-5xx-rate' at 14:32 UTC"
-ctx add-note "METRICS: error_rate = 15.2% (threshold: 1%)"
-ctx add-note "CHECK: Database connections - HEALTHY"
-ctx add-note "CHECK: External payment gateway - DEGRADED (timeouts)"
-ctx add-note "LOG: 'Connection timeout after 30000ms' in payment-gateway-client.log"
+ctx note "DETECTED: CloudWatch alarm 'payment-api-5xx-rate' at 14:32 UTC"
+ctx note "METRICS: error_rate = 15.2% (threshold: 1%)"
+ctx note "CHECK: Database connections - HEALTHY"
+ctx note "CHECK: External payment gateway - DEGRADED (timeouts)"
+ctx note "LOG: 'Connection timeout after 30000ms' in payment-gateway-client.log"
 
 # Mitigation
 echo -e "\n🛠️ Mitigation Actions:"
-ctx add-note "ACTION: Increased timeout from 30s to 60s - PARTIAL_SUCCESS"
-ctx add-note "ACTION: Enabled circuit breaker with 50% threshold - SUCCESS"
-ctx add-note "WORKAROUND: Routing 50% traffic to backup gateway at 14:45"
-ctx add-note "METRICS: error_rate dropping - now at 2.1%"
+ctx note "ACTION: Increased timeout from 30s to 60s - PARTIAL_SUCCESS"
+ctx note "ACTION: Enabled circuit breaker with 50% threshold - SUCCESS"
+ctx note "WORKAROUND: Routing 50% traffic to backup gateway at 14:45"
+ctx note "METRICS: error_rate dropping - now at 2.1%"
 
 # Escalation
-ctx set-status 🚨
-ctx add-note "ESCALATION: Paged payment gateway vendor - ticket #PG-8834"
-ctx add-note "CORRELATION: Vendor confirmed regional degradation starting 14:25"
+ctx set-state 🚨
+ctx note "ESCALATION: Paged payment gateway vendor - ticket #PG-8834"
+ctx note "CORRELATION: Vendor confirmed regional degradation starting 14:25"
 
 # Resolution
 echo -e "\n✅ Resolution:"
-ctx add-note "ACTION: Vendor resolved issue at 15:10"
-ctx add-note "ACTION: Restored normal traffic routing at 15:20"
-ctx add-note "METRICS: error_rate = 0.1% - back to normal"
-ctx set-status 📊
+ctx note "ACTION: Vendor resolved issue at 15:10"
+ctx note "ACTION: Restored normal traffic routing at 15:20"
+ctx note "METRICS: error_rate = 0.1% - back to normal"
+ctx set-state 📊
 
 # Post-incident
 echo -e "\n📊 Post-Incident Review:"
-ctx add-note "RCA: Payment gateway provider had database failover issue"
-ctx add-note "PREVENTION: 1) Implement multi-region gateway failover"
-ctx add-note "PREVENTION: 2) Reduce timeout to fail faster (10s)"
-ctx add-note "PREVENTION: 3) Add pre-emptive health checks"
+ctx note "RCA: Payment gateway provider had database failover issue"
+ctx note "PREVENTION: 1) Implement multi-region gateway failover"
+ctx note "PREVENTION: 2) Reduce timeout to fail faster (10s)"
+ctx note "PREVENTION: 3) Add pre-emptive health checks"
 
 ctx status

--- a/examples/agent-qa-testing.sh
+++ b/examples/agent-qa-testing.sh
@@ -5,37 +5,37 @@ echo "=== QA Testing Agent Workflow ==="
 
 # Initialize test context
 ctx create PAYMENT-5320-qa-regression
-ctx set-status 🧪
-ctx add-note "TEST_SUITE: Payment Regression Suite | ENV: staging"
-ctx add-note "BUILD: 2025.1.234 | VERSION: 25.10.1"
-ctx add-note "SCOPE: Refund endpoints | PRIORITY: P1"
+ctx set-state 🧪
+ctx note "TEST_SUITE: Payment Regression Suite | ENV: staging"
+ctx note "BUILD: 2025.1.234 | VERSION: 25.10.1"
+ctx note "SCOPE: Refund endpoints | PRIORITY: P1"
 
 # Test execution
 echo -e "\n🧪 Test Execution:"
-ctx add-note "TC_001: Create refund - PASS"
-ctx add-note "TC_002: Partial refund - PASS"
-ctx add-note "TC_003: Duplicate refund prevention - FAIL"
-ctx add-note "FAILURE: Expected 409, got 200 | SCREENSHOT: /logs/tc003_fail.png"
+ctx note "TC_001: Create refund - PASS"
+ctx note "TC_002: Partial refund - PASS"
+ctx note "TC_003: Duplicate refund prevention - FAIL"
+ctx note "FAILURE: Expected 409, got 200 | SCREENSHOT: /logs/tc003_fail.png"
 
 # Defect found
 echo -e "\n🐛 Defect Tracking:"
-ctx set-status 🐛
-ctx add-note "DEFECT: BUG-4521 - P2 - RefundService"
-ctx add-note "REPRO: 1) Create order 2) Process refund 3) Repeat refund with same ID"
-ctx add-note "EXPECTED: 409 Conflict | ACTUAL: 200 OK with duplicate refund"
+ctx set-state 🐛
+ctx note "DEFECT: BUG-4521 - P2 - RefundService"
+ctx note "REPRO: 1) Create order 2) Process refund 3) Repeat refund with same ID"
+ctx note "EXPECTED: 409 Conflict | ACTUAL: 200 OK with duplicate refund"
 
 # Performance testing
 echo -e "\n⚡ Performance Results:"
-ctx add-note "API_TEST: POST /api/v1/refunds - 201 Created"
-ctx add-note "RESPONSE_TIME: 145ms avg (min: 89ms, max: 412ms)"
-ctx add-note "LOAD: 100 users, 5 min duration"
-ctx add-note "RESULT: CPU = 45% (+15% from baseline)"
+ctx note "API_TEST: POST /api/v1/refunds - 201 Created"
+ctx note "RESPONSE_TIME: 145ms avg (min: 89ms, max: 412ms)"
+ctx note "LOAD: 100 users, 5 min duration"
+ctx note "RESULT: CPU = 45% (+15% from baseline)"
 
 # Test summary
 echo -e "\n📊 Test Summary:"
-ctx add-note "SUMMARY: 85% pass | 2 defects | 1 blocked"
-ctx add-note "REGRESSION: Authentication suite - 48/50 passed"
-ctx add-note "FLAKY: TC_045 - 30% failure rate over 10 runs"
+ctx note "SUMMARY: 85% pass | 2 defects | 1 blocked"
+ctx note "REGRESSION: Authentication suite - 48/50 passed"
+ctx note "FLAKY: TC_045 - 30% failure rate over 10 runs"
 
 # Show status
 ctx status

--- a/examples/sprint_workflow.py
+++ b/examples/sprint_workflow.py
@@ -58,7 +58,7 @@ class SprintWorkflow:
             notes.append(f"PR: #{pr_number}")
 
         for note in notes:
-            self.run_ctx(f'add-note "{note}"')
+            self.run_ctx(f'note "{note}"')
 
         # Set initial status
         self.set_phase("new")
@@ -67,12 +67,12 @@ class SprintWorkflow:
         """Update the sprint phase"""
         if phase in self.PHASES:
             emoji = self.PHASES[phase]
-            self.run_ctx(f"set-status {emoji}")
-            self.run_ctx(f'add-note "PHASE: {phase.upper()} - {datetime.now().strftime('%H:%M')}"')
+            self.run_ctx(f"set-state {emoji}")
+            self.run_ctx(f'note "PHASE: {phase.upper()} - {datetime.now().strftime('%H:%M')}"')
 
     def add_technical_note(self, category, content):
         """Add a categorized technical note"""
-        self.run_ctx(f'add-note "{category.upper()}: {content}"')
+        self.run_ctx(f'note "{category.upper()}: {content}"')
 
     def track_pr_status(self, pr_number, status):
         """Track PR status changes"""
@@ -91,7 +91,7 @@ class SprintWorkflow:
     def generate_status_report(self):
         """Generate a status report"""
         output = self.run_ctx("status")
-        notes_output = self.run_ctx("show-notes")
+        notes_output = self.run_ctx("notes")
 
         return f"""
 Sprint Status Report: {self.sprint_id}


### PR DESCRIPTION
## Summary
- update docs/examples to use `note`, `notes`, and `set-state`
- provide legacy CLI aliases for `add-note`, `show-notes`, and `set-status`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c7cef79c83339c9608c4ec7627ba