### PR TITLE
Fix sprint workflow example

### DIFF
--- a/examples/sprint_workflow.py
+++ b/examples/sprint_workflow.py
@@ -50,7 +50,7 @@ class SprintWorkflow:
         # Add initial metadata
         notes = [
             f"SPRINT: {self.sprint_id}",
-                            f"JIRA: {jira_url or f'https://jira.example.com/browse/{self.sprint_id}'}",
+            f"JIRA: {jira_url or 'https://jira.example.com/browse/' + self.sprint_id}",
             f"CREATED: {datetime.now().strftime('%Y-%m-%d %H:%M')}"
         ]
 


### PR DESCRIPTION
## Summary
- fix nested f-string in `examples/sprint_workflow.py`

## Testing
- `python3 -m py_compile examples/sprint_workflow.py`
- `flake8 examples/sprint_workflow.py`

------
https://chatgpt.com/codex/tasks/task_e_6888dd88fb048333b135b90d52f91531